### PR TITLE
Added the ability to get the amount of confirmations with the tx hash

### DIFF
--- a/tests/main-tests.js
+++ b/tests/main-tests.js
@@ -71,6 +71,28 @@ describe('easy-bitcoin-js', function() {
         it('should return a fulfilled transaction object for a valid address');
     });
 
+    describe('getCurrentBlock', function() {
+        it('should return a block number', function() {
+            return easybtc.getCurrentBlock()
+                .then(function(result) {
+                    expect(result)
+                        .to
+                        .be.a('number')
+                });
+        });
+    });
+
+    describe('getConfirmations', function() {
+        it('should return the amount of confirmations for a transaction', function() {
+            return easybtc.getConfirmations("d4b2e1d978c338cf6b85bfb380dc0bef8b11d0663b9c3c5adee5b912c6ae7ff4")
+                .then(function(result) {
+                    expect(result)
+                        .to
+                        .be.a('number')
+                });
+        });
+    });
+
     describe('decodeTransaction', function() {
         it('should return null for an invalid hex script');
         it('should return a fulfilled transaction object for a valid hex script');


### PR DESCRIPTION
I added some functions that allow you to get the amount of confirmations of a transaction since the transaction API URL doesn't include that key.

The test file has been edited and all the new tests pass.